### PR TITLE
Improvements to the German translation

### DIFF
--- a/res/values-de/OfficialAnnouncements.xml
+++ b/res/values-de/OfficialAnnouncements.xml
@@ -6,30 +6,30 @@
     <string name="oal_pause">Pause</string>
     <string name="oa_handout">Aufschlagwechsel</string>
 
-    <string name="oa_bestOfX_or_firstToY_games__to_z">%2$s Satzspiel bis %3$s</string>
-    <string name="oa_bestOfX_or_firstToY_games">%2$s Satzspiel</string>
+    <string name="oa_bestOfX_or_firstToY_games__to_z">Spiel auf %2$s Gewinnsätze bis %3$s</string>
+    <string name="oa_bestOfX_or_firstToY_games">Spiel auf %2$s Gewinnsätze</string>
     <string name="oa_x_to_serve__y_to_receive">%1$s hat Aufschlag, %2$s Rückschläger</string>
-    <string name="sb_serve">Aufschlag</string>
+    <string name="sb_serve">Aufschläger</string>
     <string name="sb_receive">Rückschläger</string>
     <string name="oa_love_all">Null beide</string>
 
     <string name="oa_game_NamePlayerX__TennisPadel">Spiel %s</string>
     <string name="oa_game_to_x">Satz an %s</string>
     <string name="oa_match_to_x">Spiel an %s</string>
-    <string name="oa_1_game_all">1–1 in Sätzen</string>
+    <string name="oa_1_game_all">Eins beide in Sätzen</string>
     <string name="oa_x_games_all">%s beide in Sätzen</string>
     <string name="oa_1_game_all__TennisPadel">Eins beide</string>
     <string name="oa_x_games_all__TennisPadel">%s beide</string>
     <string name="oa_x_sets_all__TennisPadel">%s beide in Sätzen</string>
-    <string name="oa_1_set_all__TennisPadel">1–1 in Sätzen</string>
+    <string name="oa_1_set_all__TennisPadel">Eins beide in Sätzen</string>
     <string name="oa_a_wins_set_b_xGamesToy__TennisPadel">%1$s gewint Satz %2$d %3$s</string>
     <!--<string name="oa_x_leads_n_against_y">%1$s führt %2$s-%3$s in Sätzen gegen</string>-->
-    <!--<string name="oa_x_wins_n_against_y">Spiel an %1$s, %2$s Sätzen zu %s</string>-->
+    <!--<string name="oa_x_wins_n_against_y">Spiel an %1$s, %2$s Sätze zu %s</string>-->
     <string name="oa_a_leads_xGamesToy">%1$s führt %2$s</string>
     <string name="oa_a_wins_xGamesToy">Spiel an %1$s, %2$s</string>
     <string name="oa_x_games_TO_y">zu</string>
     <string name="oa_x_th_game">%s Satz</string>
-    <string name="oa_x_to_serve">Aufschläger %s</string>
+    <string name="oa_x_to_serve">%s schlägt auf</string>
     <string name="oa_love">0</string>
     <string name="oa_match_firstletter">M</string>
     <string name="oa_game_firstletter">S</string>
@@ -47,12 +47,12 @@
     <string name="oa_set_ball">Satzball</string>
 
     <string name="oa_n_all__or__n_equal">%d beide</string>
-    <string name="oa_player_needs_2_clear_points">Ein Spieler muss mit 2 Punkten vorsprung gewinnen</string>
+    <string name="oa_player_needs_2_clear_points">Es bedarf 2 Punkte Vorsprung, um einen Satz zu gewinnen</string>
 
     <string name="oa_change_sides"></string>
     <string name="oa_fifteen_seconds">%s Sekunden!</string>
 
-    <string name="oa_decision_colon">Entscheidung :</string>
+    <string name="oa_decision_colon">Entscheidung:</string>
     <string name="oa_yes_let">Let Ball</string>
     <string name="oa_no_let">Kein Let</string>
     <string name="oa_stroke">Ball an</string>


### PR DESCRIPTION
Here are a couple of small improvements to the German translation. It isn't perfect yet, but I am not sure all issues can be resolved without greater effort.

Here are the two problems I couldn't fix properly:

1. Consider `oa_best_of_x_games`, which is how it works in English. But instead of "best of 5 games", in German, we say that one needs "3 Gewinnsätze". Curiously, the internals of the app work the same (`matchModel.getNrOfGamesToWinMatch()`), but that's then [converted to best-of format](https://github.com/obbimi/Squore/blob/39b3cabdb59594e422185da71d92b19c9576d833/src/com/doubleyellow/scoreboard/dialog/MatchInfo.java#L104). Short of special-casing for languages in the code, I don't really see a better way than to use English "best of" even in German.
2. The array `FirstSecondThirdFourthFifth` is highly specific, and can only be used in its original form to for feminine or neutre words, or masculine words that have an article ("*Der* erste Satz" vs. "Erster Satz" without the article). I checked the code, and I think this array is only ever used in combination with `oa_x_th_game`, and so changing it to the masculine form seems ok.